### PR TITLE
chore: add common OS, IDE, and tooling patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,22 @@ dist
 .turbo
 *.tsbuildinfo
 
+# OS files
+.DS_Store
+Thumbs.db
+
+# IDE / editor
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# Logs
+*.log
+
+# Test coverage
+coverage/
+
 # Generated channel account keys (contain secrets)
 examples/facilitator/scripts/output/
 


### PR DESCRIPTION
Add missing entries for macOS (.DS_Store), Windows (Thumbs.db), IDE directories (.idea, .vscode), editor swap files, log files, and test coverage output.