### PR TITLE
fix: sanitize HTML response before DOM injection to prevent XSS

### DIFF
--- a/packages/paywall/src/browser/entry.tsx
+++ b/packages/paywall/src/browser/entry.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import type {} from "./window";
 import { StellarPaywall } from "./StellarPaywall";
 import { validateX402Config } from "./validate";
+import { sanitizeHTML } from "./sanitize";
 
 // Stellar-specific paywall entry point
 window.addEventListener("load", () => {
@@ -42,7 +43,7 @@ window.addEventListener("load", () => {
       onSuccessfulResponse={async (response: Response) => {
         const contentType = response.headers.get("content-type");
         if (contentType && contentType.includes("text/html")) {
-          document.documentElement.innerHTML = await response.text();
+          document.documentElement.innerHTML = sanitizeHTML(await response.text());
         } else {
           const blob = await response.blob();
           const url = window.URL.createObjectURL(blob);

--- a/packages/paywall/src/browser/sanitize.ts
+++ b/packages/paywall/src/browser/sanitize.ts
@@ -1,0 +1,26 @@
+const EVENT_HANDLER_RE = /^on/i;
+
+/**
+ * Parse an HTML string with DOMParser and strip dangerous content
+ * (script/iframe/object/embed elements and inline event-handler attributes)
+ * before it is injected into the document via innerHTML.
+ */
+export function sanitizeHTML(raw: string): string {
+  const doc = new DOMParser().parseFromString(raw, "text/html");
+
+  const dangerous = doc.querySelectorAll("script, iframe, object, embed");
+  for (const el of dangerous) {
+    el.remove();
+  }
+
+  const all = doc.querySelectorAll("*");
+  for (const el of all) {
+    for (const attr of [...el.attributes]) {
+      if (EVENT_HANDLER_RE.test(attr.name)) {
+        el.removeAttribute(attr.name);
+      }
+    }
+  }
+
+  return doc.documentElement.innerHTML;
+}


### PR DESCRIPTION
## Summary

Fixes a potential **XSS vulnerability** in the paywall browser entry.

Previously, `packages/paywall/src/browser/entry.tsx` injected server responses directly into the DOM using:

```ts
document.documentElement.innerHTML = await response.text()
```

While `<script>` tags are not executed when inserted via `innerHTML`, **inline event handlers** (`onerror`, `onclick`, `onload`, etc.) can still execute.  
If the response is tampered with (e.g. MITM or compromised upstream), this could lead to **DOM-based XSS**.

To mitigate this, a sanitization layer has been added before DOM injection.

---

## Changes

| File | Description |
|-----|-------------|
| `packages/paywall/src/browser/sanitize.ts` | Added `sanitizeHTML()` utility |
| `packages/paywall/src/browser/entry.tsx` | Sanitize server response before assigning to `innerHTML` |

### Sanitization behavior

`sanitizeHTML()`:

- Parses HTML using `DOMParser`
- Removes dangerous elements:
  - `script`
  - `iframe`
  - `object`
  - `embed`
- Strips all inline event handler attributes (`on*`)

---

## Test Plan

- [ ] `pnpm --filter @x402-stellar/paywall typecheck` passes  
- [ ] Paywall still renders protected HTML after successful payment  
- [ ] Malicious payloads like:

```html
<img src=x onerror="alert(1)">
```

are neutralized after sanitization