### PR TITLE
Add testnet refund scripts and shared helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ On Stellar, a single account can only submit one transaction at a time because e
 
 ```bash
 cd examples/facilitator
-pnpm generate-channels
+pnpm generate-channel-accounts
 ```
 
 This will:
@@ -197,7 +197,7 @@ This will:
 - Create a fee-payer keypair and fund it via Friendbot
 - Generate 19 channel account keypairs
 - Create all channel accounts on-chain with zero balance (using sponsored reserves)
-- Save all keys to a timestamped JSON file under `scripts/output/`
+- Save all keys to a timestamped `.env` file under `scripts/output/`
 - Print the environment variables to add to your `.env`
 
 2. Copy the output into your `.env`:
@@ -218,6 +218,22 @@ pnpm dev
 You should see a log line: `High-throughput mode: fee-bump signer + channel accounts`.
 
 When the channel account variables are not set, the facilitator falls back to single-signer mode using `FACILITATOR_STELLAR_PRIVATE_KEY`.
+
+### Testnet Reset Recovery
+
+Stellar's public testnet resets periodically, wiping all accounts. Two utility scripts re-fund your accounts without regenerating keys:
+
+```bash
+cd examples/facilitator
+
+# Re-fund accounts from your .env file
+pnpm refund-accounts-from-env
+
+# Re-fund all signers registered with x402.org
+pnpm refund-accounts-from-remote
+```
+
+Both scripts skip accounts that are already funded. See `examples/facilitator/README.md` for details.
 
 ## Adding a New Example
 

--- a/examples/facilitator/README.md
+++ b/examples/facilitator/README.md
@@ -52,7 +52,7 @@ When both `FACILITATOR_STELLAR_FEE_BUMP_SECRET` and `FACILITATOR_STELLAR_CHANNEL
 A bundled script creates 1 fee-payer account + 19 channel accounts on testnet in a single transaction:
 
 ```bash
-pnpm generate-channels
+pnpm generate-channel-accounts
 ```
 
 This will:
@@ -61,7 +61,7 @@ This will:
 2. Generate 19 channel account keypairs
 3. Create all 19 accounts on-chain with **zero balance** using sponsored reserves (`BeginSponsoringFutureReserves` + `CreateAccount` + `EndSponsoringFutureReserves`)
 4. Submit the transaction and wait for confirmation
-5. Save all keys to a timestamped JSON file in `scripts/output/`
+5. Save all keys to a timestamped `.env` file in `scripts/output/`
 6. Print the two environment variables to add to `.env`
 
 Example output:
@@ -90,6 +90,16 @@ INFO: High-throughput mode: fee-bump signer + channel accounts
 ```
 
 When the channel account variables are absent or empty, the facilitator falls back to single-signer mode -- no changes needed.
+
+## Utility Scripts
+
+| Script                             | Description                                                                           |
+| ---------------------------------- | ------------------------------------------------------------------------------------- |
+| `pnpm generate-channel-accounts`   | Create 1 fee-payer + 19 channel accounts on testnet (saves keys to `scripts/output/`) |
+| `pnpm refund-accounts-from-env`    | Re-fund facilitator accounts from `.env` secrets after a testnet reset                |
+| `pnpm refund-accounts-from-remote` | Fund signer addresses fetched from a remote facilitator's `/supported` endpoint       |
+
+After a testnet reset all accounts are wiped. The refund scripts call Friendbot to re-activate existing accounts — they do **not** re-create sponsored-reserve relationships. Each account receives 10,000 XLM independently.
 
 ## Development
 

--- a/examples/facilitator/package.json
+++ b/examples/facilitator/package.json
@@ -11,7 +11,9 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
-    "generate-channels": "tsx scripts/generate-channel-accounts.ts"
+    "generate-channel-accounts": "tsx scripts/generate-channel-accounts.ts",
+    "refund-accounts-from-env": "tsx scripts/refund-accounts-from-env.ts",
+    "refund-accounts-from-remote": "tsx scripts/refund-accounts-from-remote.ts"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^14.5.0",

--- a/examples/facilitator/scripts/generate-channel-accounts.ts
+++ b/examples/facilitator/scripts/generate-channel-accounts.ts
@@ -6,7 +6,7 @@
  * CreateAccount + EndSponsoringFutureReserves).
  *
  * Outputs:
- *  - A timestamped JSON file under scripts/output/ with all generated keys
+ *  - A timestamped .env file under scripts/output/ with the generated secrets
  *  - The env variables to paste into .env
  *
  * Usage:
@@ -22,27 +22,11 @@ import {
   BASE_FEE,
 } from "@stellar/stellar-sdk";
 import { rpc as StellarRpc } from "@stellar/stellar-sdk";
-import * as fs from "node:fs";
-import * as path from "node:path";
+
+import { TESTNET_RPC, fundWithFriendbot, saveEnvFile } from "./lib/stellar-helpers.js";
 
 const CHANNEL_COUNT = 19;
-const TESTNET_RPC = process.env.STELLAR_RPC_URL?.trim() || "https://soroban-testnet.stellar.org";
-const TESTNET_FRIENDBOT = "https://friendbot.stellar.org";
 const TESTNET_PASSPHRASE = process.env.STELLAR_NETWORK_PASSPHRASE?.trim() || Networks.TESTNET;
-
-interface GeneratedAccount {
-  publicKey: string;
-  secretKey: string;
-}
-
-async function fundWithFriendbot(address: string): Promise<void> {
-  const url = `${TESTNET_FRIENDBOT}?addr=${address}`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    const body = await response.text();
-    throw new Error(`Friendbot funding failed for ${address}: ${response.status} ${body}`);
-  }
-}
 
 async function main() {
   console.log("=== Stellar Channel Account Generator ===\n");
@@ -58,13 +42,9 @@ async function main() {
   console.log("Fee payer funded.\n");
 
   // 3. Generate channel account keypairs
-  const channels: { keypair: Keypair; account: GeneratedAccount }[] = [];
+  const channels: Keypair[] = [];
   for (let i = 0; i < CHANNEL_COUNT; i++) {
-    const kp = Keypair.random();
-    channels.push({
-      keypair: kp,
-      account: { publicKey: kp.publicKey(), secretKey: kp.secret() },
-    });
+    channels.push(Keypair.random());
   }
   console.log(`Generated ${CHANNEL_COUNT} channel account keypairs.\n`);
 
@@ -79,27 +59,24 @@ async function main() {
   });
 
   for (const ch of channels) {
-    // BeginSponsoringFutureReserves: fee payer sponsors the channel account
     builder.addOperation(
       Operation.beginSponsoringFutureReserves({
-        sponsoredId: ch.keypair.publicKey(),
+        sponsoredId: ch.publicKey(),
         source: feePayer.publicKey(),
       }),
     );
 
-    // CreateAccount with zero balance (sponsored)
     builder.addOperation(
       Operation.createAccount({
-        destination: ch.keypair.publicKey(),
+        destination: ch.publicKey(),
         startingBalance: "0",
         source: feePayer.publicKey(),
       }),
     );
 
-    // EndSponsoringFutureReserves: the channel account confirms sponsorship
     builder.addOperation(
       Operation.endSponsoringFutureReserves({
-        source: ch.keypair.publicKey(),
+        source: ch.publicKey(),
       }),
     );
   }
@@ -112,7 +89,7 @@ async function main() {
 
   // Sign with each channel account (source of EndSponsoring)
   for (const ch of channels) {
-    transaction.sign(ch.keypair);
+    transaction.sign(ch);
   }
 
   // 5. Submit the transaction
@@ -139,31 +116,21 @@ async function main() {
     process.exit(1);
   }
 
-  // 6. Save to timestamped file
-  const outputDir = path.join(import.meta.dirname, "output");
-  fs.mkdirSync(outputDir, { recursive: true });
-
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const outputFile = path.join(outputDir, `${timestamp}.json`);
-
-  const output = {
-    generatedAt: new Date().toISOString(),
-    transactionHash: result.hash,
-    feePayer: {
-      publicKey: feePayer.publicKey(),
-      secretKey: feePayer.secret(),
-    },
-    channelAccounts: channels.map((ch) => ch.account),
+  // 6. Save to timestamped .env file
+  const channelSecrets = channels.map((ch) => ch.secret()).join(",");
+  const envEntries = {
+    FACILITATOR_STELLAR_FEE_BUMP_SECRET: feePayer.secret(),
+    FACILITATOR_STELLAR_CHANNEL_SECRETS: channelSecrets,
   };
 
-  fs.writeFileSync(outputFile, JSON.stringify(output, null, 2));
+  const outputFile = saveEnvFile(envEntries);
   console.log(`Accounts saved to: ${outputFile}\n`);
 
   // 7. Print env variables
-  const channelSecrets = channels.map((ch) => ch.account.secretKey).join(",");
   console.log("=== Environment Variables ===\n");
-  console.log(`FACILITATOR_STELLAR_FEE_BUMP_SECRET=${feePayer.secret()}`);
-  console.log(`FACILITATOR_STELLAR_CHANNEL_SECRETS=${channelSecrets}`);
+  for (const [key, value] of Object.entries(envEntries)) {
+    console.log(`${key}=${value}`);
+  }
   console.log("\nCopy these into your .env file.");
 }
 

--- a/examples/facilitator/scripts/lib/stellar-helpers.ts
+++ b/examples/facilitator/scripts/lib/stellar-helpers.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared helpers for facilitator scripts.
+ *
+ * Centralises Friendbot funding, testnet constants, and file-output logic
+ * so that every script in this directory stays DRY.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { rpc as StellarRpc } from "@stellar/stellar-sdk";
+
+export const TESTNET_RPC =
+  process.env.STELLAR_RPC_URL?.trim() || "https://soroban-testnet.stellar.org";
+
+export const TESTNET_FRIENDBOT = "https://friendbot.stellar.org";
+
+export async function isAccountFunded(
+  address: string,
+  server: StellarRpc.Server,
+): Promise<boolean> {
+  try {
+    await server.getAccount(address);
+    return true;
+  } catch (error: unknown) {
+    // The SDK's getAccountEntry throws `Error("Account not found: <addr>")`
+    // when the ledger entry doesn't exist.  Any other failure (network
+    // timeout, RPC error, etc.) should bubble up so callers can handle it.
+    if (error instanceof Error && error.message.startsWith("Account not found:")) {
+      return false;
+    }
+    throw error;
+  }
+}
+
+/** @throws if Friendbot returns a non-2xx response. */
+export async function fundWithFriendbot(address: string): Promise<void> {
+  const url = `${TESTNET_FRIENDBOT}?addr=${address}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Friendbot funding failed for ${address}: ${response.status} ${body}`);
+  }
+}
+
+/** Fund multiple addresses sequentially via Friendbot, skipping already-funded accounts. */
+export async function fundAddressesWithFriendbot(
+  addresses: string[],
+  { label = "address" }: { label?: string } = {},
+): Promise<void> {
+  const server = new StellarRpc.Server(TESTNET_RPC);
+  for (let i = 0; i < addresses.length; i++) {
+    const addr = addresses[i];
+    const prefix = `  ${label} ${i + 1}/${addresses.length} (${addr})`;
+    if (await isAccountFunded(addr, server)) {
+      console.log(`${prefix}: already funded, skipping`);
+      continue;
+    }
+    console.log(`${prefix}: funding via Friendbot...`);
+    await fundWithFriendbot(addr);
+  }
+}
+
+const OUTPUT_DIR = path.join(import.meta.dirname, "..", "output");
+
+/** Write env-var lines to `scripts/output/<timestamp>.env`. Returns the file path. */
+export function saveEnvFile(entries: Record<string, string>): string {
+  fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const outputFile = path.join(OUTPUT_DIR, `${timestamp}.env`);
+  const content = Object.entries(entries)
+    .map(([key, value]) => `${key}=${value}`)
+    .join("\n");
+  fs.writeFileSync(outputFile, content + "\n");
+  return outputFile;
+}

--- a/examples/facilitator/scripts/refund-accounts-from-env.ts
+++ b/examples/facilitator/scripts/refund-accounts-from-env.ts
@@ -1,0 +1,73 @@
+/**
+ * Re-fund facilitator accounts via Friendbot after a testnet reset.
+ *
+ * Reads secret keys from environment variables, derives public addresses,
+ * and funds any that are not already active on the network.
+ *
+ * At least one of the following must be set:
+ *   FACILITATOR_STELLAR_PRIVATE_KEY
+ *   FACILITATOR_STELLAR_FEE_BUMP_SECRET + FACILITATOR_STELLAR_CHANNEL_SECRETS
+ *
+ * All present env vars are processed — they are not mutually exclusive.
+ *
+ * Usage:
+ *   npx tsx scripts/refund-accounts-from-env.ts
+ */
+
+import "dotenv/config";
+
+import { Keypair } from "@stellar/stellar-sdk";
+
+import { fundAddressesWithFriendbot } from "./lib/stellar-helpers.js";
+
+async function main() {
+  console.log("=== Refund Facilitator Accounts ===\n");
+
+  const facilitatorSecret = process.env.FACILITATOR_STELLAR_PRIVATE_KEY?.trim() || undefined;
+  const feeBumpSecret = process.env.FACILITATOR_STELLAR_FEE_BUMP_SECRET?.trim() || undefined;
+  const channelSecretsRaw = process.env.FACILITATOR_STELLAR_CHANNEL_SECRETS?.trim() || undefined;
+
+  if (!facilitatorSecret && !feeBumpSecret && !channelSecretsRaw) {
+    throw new Error(
+      "No accounts to fund. Set FACILITATOR_STELLAR_PRIVATE_KEY and/or " +
+        "(FACILITATOR_STELLAR_FEE_BUMP_SECRET + FACILITATOR_STELLAR_CHANNEL_SECRETS) " +
+        "in your .env or environment.",
+    );
+  }
+
+  const addresses: string[] = [];
+
+  if (facilitatorSecret) {
+    const addr = Keypair.fromSecret(facilitatorSecret).publicKey();
+    console.log(`Facilitator: ${addr}`);
+    addresses.push(addr);
+  }
+
+  if (feeBumpSecret) {
+    const addr = Keypair.fromSecret(feeBumpSecret).publicKey();
+    console.log(`Fee-bump signer: ${addr}`);
+    addresses.push(addr);
+  }
+
+  if (channelSecretsRaw) {
+    const channelSecrets = channelSecretsRaw
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    for (const secret of channelSecrets) {
+      addresses.push(Keypair.fromSecret(secret).publicKey());
+    }
+    console.log(`Channel accounts: ${channelSecrets.length}`);
+  }
+
+  console.log(`\nTotal accounts to check: ${addresses.length}\n`);
+
+  await fundAddressesWithFriendbot(addresses, { label: "account" });
+
+  console.log("\nDone.");
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/examples/facilitator/scripts/refund-accounts-from-remote.ts
+++ b/examples/facilitator/scripts/refund-accounts-from-remote.ts
@@ -1,0 +1,63 @@
+/**
+ * Fund Stellar signer addresses listed on a remote facilitator's /supported endpoint.
+ *
+ * Fetches the endpoint, extracts all addresses from "signers"."stellar:*",
+ * and funds any that are not already active on the network via Friendbot.
+ *
+ * Usage:
+ *   npx tsx scripts/refund-accounts-from-remote.ts                           # uses default URL
+ *   npx tsx scripts/refund-accounts-from-remote.ts https://custom-url/facilitator/supported
+ */
+
+import { fundAddressesWithFriendbot } from "./lib/stellar-helpers.js";
+
+const DEFAULT_SUPPORTED_URL = "https://www.x402.org/facilitator/supported";
+
+interface SupportedResponse {
+  signers: Record<string, string[]>;
+}
+
+function extractStellarAddresses(signers: Record<string, string[]>): string[] {
+  const addresses: string[] = [];
+  for (const [key, values] of Object.entries(signers)) {
+    if (key.startsWith("stellar:")) {
+      addresses.push(...values);
+    }
+  }
+  return [...new Set(addresses)];
+}
+
+async function main() {
+  const supportedUrl = process.argv[2] || DEFAULT_SUPPORTED_URL;
+
+  console.log("=== Fund Facilitator Signers ===\n");
+  console.log(`Fetching: ${supportedUrl}\n`);
+
+  const response = await fetch(supportedUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${supportedUrl}: ${response.status} ${await response.text()}`);
+  }
+
+  const data = (await response.json()) as SupportedResponse;
+  const addresses = extractStellarAddresses(data.signers ?? {});
+
+  if (addresses.length === 0) {
+    console.log("No Stellar signer addresses found in the /supported response.");
+    return;
+  }
+
+  console.log(`Found ${addresses.length} Stellar signer address(es):\n`);
+  for (const addr of addresses) {
+    console.log(`  ${addr}`);
+  }
+  console.log();
+
+  await fundAddressesWithFriendbot(addresses, { label: "signer" });
+
+  console.log("\nDone.");
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **New**: `refund-accounts-from-env` script — re-funds facilitator accounts from `.env` secrets after a testnet reset
- **New**: `refund-accounts-from-remote` script — fetches signer addresses from a remote `/supported` endpoint and funds them via Friendbot
- **New**: `scripts/lib/stellar-helpers.ts` — shared module with `isAccountFunded()`, `fundWithFriendbot()`, `fundAddressesWithFriendbot()`, and `saveEnvFile()`
- **Refactored**: `generate-channel-accounts` to use shared helpers, simplified keypair handling, outputs `.env` instead of JSON
- **Updated**: Both READMEs with correct script names, `.env` file references, and a new "Utility Scripts" section in the facilitator README + "Testnet Reset Recovery" in the root README

## Details

All three scripts share common code via `stellar-helpers.ts` to stay DRY. The refund scripts skip already-funded accounts by checking on-chain existence before calling Friendbot. Env var validation in `refund-accounts-from-env` treats all three env vars as individually optional but requires at least one to be present — all present vars are processed.

### npm scripts added

| Command | Description |
|---|---|
| `pnpm generate-channel-accounts` | Create 1 fee-payer + 19 channel accounts on testnet |
| `pnpm refund-accounts-from-env` | Re-fund accounts from local `.env` secrets |
| `pnpm refund-accounts-from-remote` | Fund signers from remote `/supported` endpoint |