### PR TITLE
Fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/stellar/x402-stellar/security/code-scanning/19](https://github.com/stellar/x402-stellar/security/code-scanning/19)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. Since the jobs here only read repository contents (via `actions/checkout`) and then run local commands, they can operate with `contents: read` and do not need any write permissions or access to other scopes like `issues` or `pull-requests`.

The best minimal fix without changing functionality is to add a top‑level `permissions` block (applies to all jobs) in `.github/workflows/test.yml`, alongside `name`, `on`, and `concurrency`. We set `contents: read` (and optionally nothing else) so that `GITHUB_TOKEN` is restricted to read‑only repository contents, which is sufficient for `actions/checkout` and all subsequent steps. No imports or additional methods are needed; this is purely a YAML configuration change.

Concretely, edit `.github/workflows/test.yml` to insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (e.g., after line 8), before `concurrency:`. No changes to the `jobs:` definitions or steps are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
