### PR TITLE
chore: patch axios to 1.15.0 (Dependabot alerts #14, #15)

### DIFF
--- a/examples/client-cli/src/index.ts
+++ b/examples/client-cli/src/index.ts
@@ -127,7 +127,10 @@ async function main(): Promise<void> {
     const facilitatorError =
       paidResponse.status === 402
         ? getX402ErrorMessage(
-            parseX402Header<Record<string, unknown>>(paidResponse.headers.get("payment-required")),
+            parseX402Header<Record<string, unknown>>(
+              paidResponse.headers.get("payment-required"),
+              (err) => logger.warn({ err }, "Malformed payment-required header"),
+            ),
           )
         : undefined;
     logger.error(

--- a/examples/facilitator/.env.example
+++ b/examples/facilitator/.env.example
@@ -20,3 +20,6 @@ STELLAR_NETWORK=stellar:testnet
 # Security
 # TRUST_PROXY=loopback,linklocal,uniquelocal
 # CORS_ORIGINS=http://localhost:3001
+# Optional: Bearer token that clients must send in Authorization header.
+# When unset the facilitator is open (suitable for local/private networks only).
+# FACILITATOR_API_KEY=your-secret-key-here

--- a/examples/facilitator/package.json
+++ b/examples/facilitator/package.json
@@ -24,6 +24,7 @@
     "cors": "^2.8.6",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.3.2",
     "helmet": "^8.1.0",
     "pino": "^10.3.1",
     "pino-http": "^11.0.0",

--- a/examples/facilitator/src/app.ts
+++ b/examples/facilitator/src/app.ts
@@ -10,6 +10,7 @@ import { ExactStellarScheme } from "@x402/stellar/exact/facilitator";
 import cors from "cors";
 import express, { type Express, type NextFunction, type Request, type Response } from "express";
 import helmet from "helmet";
+import { createHash, timingSafeEqual } from "node:crypto";
 import proxyAddr from "proxy-addr";
 
 import { Env } from "./config/env.js";
@@ -89,7 +90,26 @@ export function createApp(): Express {
   app.use(httpLogger);
   app.use(express.json());
 
-  app.post("/verify", async (req, res): Promise<void> => {
+  const expectedApiKey = Env.apiKey;
+  function requireApiKey(req: Request, res: Response, next: NextFunction): void {
+    if (!expectedApiKey) {
+      next();
+      return;
+    }
+    const provided = req.headers.authorization?.replace(/^Bearer\s+/i, "") ?? "";
+    // Hash both values with SHA-256 before comparing so that (a) the buffers are
+    // always the same length (avoiding a length-based timing side-channel) and
+    // (b) timingSafeEqual can run to completion regardless of key length.
+    const providedHash = createHash("sha256").update(provided).digest();
+    const expectedHash = createHash("sha256").update(expectedApiKey).digest();
+    if (!timingSafeEqual(providedHash, expectedHash)) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    next();
+  }
+
+  app.post("/verify", requireApiKey, async (req, res): Promise<void> => {
     try {
       const { paymentPayload, paymentRequirements } = req.body ?? {};
 
@@ -125,7 +145,7 @@ export function createApp(): Express {
     }
   });
 
-  app.post("/settle", async (req, res): Promise<void> => {
+  app.post("/settle", requireApiKey, async (req, res): Promise<void> => {
     const { paymentPayload, paymentRequirements } = req.body ?? {};
     try {
       const payloadError = validatePaymentPayload(paymentPayload);
@@ -150,7 +170,7 @@ export function createApp(): Express {
       logger.error({ err: error }, "Settle error");
 
       if (error instanceof Error && error.message.includes("Settlement aborted:")) {
-        res.json({
+        res.status(502).json({
           success: false,
           transaction: "",
           errorReason: "Settlement aborted",
@@ -163,7 +183,7 @@ export function createApp(): Express {
     }
   });
 
-  app.get("/supported", async (_req, res) => {
+  app.get("/supported", requireApiKey, async (_req, res) => {
     try {
       const response = facilitator.getSupported();
       res.json(response);

--- a/examples/facilitator/src/app.ts
+++ b/examples/facilitator/src/app.ts
@@ -11,6 +11,7 @@ import cors from "cors";
 import express, { type Express, type NextFunction, type Request, type Response } from "express";
 import helmet from "helmet";
 import { createHash, timingSafeEqual } from "node:crypto";
+import rateLimit from "express-rate-limit";
 import proxyAddr from "proxy-addr";
 
 import { Env } from "./config/env.js";
@@ -109,7 +110,17 @@ export function createApp(): Express {
     next();
   }
 
-  app.post("/verify", requireApiKey, async (req, res): Promise<void> => {
+  // Rate-limit auth-protected endpoints to mitigate brute-force against the API key
+  // and to cap resource consumption on /verify (RPC simulation) and /settle (XLM fees).
+  const authRateLimit = rateLimit({
+    windowMs: 60_000,
+    max: 120,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: "Too Many Requests" },
+  });
+
+  app.post("/verify", authRateLimit, requireApiKey, async (req, res): Promise<void> => {
     try {
       const { paymentPayload, paymentRequirements } = req.body ?? {};
 
@@ -145,7 +156,7 @@ export function createApp(): Express {
     }
   });
 
-  app.post("/settle", requireApiKey, async (req, res): Promise<void> => {
+  app.post("/settle", authRateLimit, requireApiKey, async (req, res): Promise<void> => {
     const { paymentPayload, paymentRequirements } = req.body ?? {};
     try {
       const payloadError = validatePaymentPayload(paymentPayload);
@@ -183,7 +194,7 @@ export function createApp(): Express {
     }
   });
 
-  app.get("/supported", requireApiKey, async (_req, res) => {
+  app.get("/supported", authRateLimit, requireApiKey, async (_req, res) => {
     try {
       const response = facilitator.getSupported();
       res.json(response);

--- a/examples/facilitator/src/config/env.ts
+++ b/examples/facilitator/src/config/env.ts
@@ -90,4 +90,13 @@ export class Env {
     const defaultValue = "loopback,linklocal,uniquelocal";
     return parseCommaSeparatedList(raw ?? defaultValue);
   }
+
+  /**
+   * Optional API key for authenticating requests to the facilitator.
+   * When set, all /verify, /settle, and /supported requests must include an
+   * `Authorization: Bearer <key>` header. Unset in dev mode = open access.
+   */
+  static get apiKey(): string | undefined {
+    return process.env.FACILITATOR_API_KEY || undefined;
+  }
 }

--- a/examples/facilitator/tests/routes/facilitator.test.ts
+++ b/examples/facilitator/tests/routes/facilitator.test.ts
@@ -170,7 +170,7 @@ describe("POST /settle", () => {
       paymentRequirements: validPaymentRequirements,
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(502);
     expect(res.body).toHaveProperty("transaction");
     expect(res.body.success).toBe(false);
   });
@@ -185,7 +185,7 @@ describe("POST /settle", () => {
         paymentRequirements: { ...validPaymentRequirements, network: "stellar:pubnet" },
       });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(502);
     expect(res.body.success).toBe(false);
     expect(res.body.network).toBe("stellar:pubnet");
   });
@@ -225,7 +225,7 @@ describe("POST /settle", () => {
       paymentRequirements: validPaymentRequirements,
     });
 
-    expect(res.status).toBe(200);
+    expect(res.status).toBe(502);
     expect(res.body.success).toBe(false);
     expect(res.body.errorReason).not.toContain("GABC123");
     expect(res.body.errorReason).not.toContain("soroban-rpc");
@@ -261,5 +261,89 @@ describe("unknown routes", () => {
   it("GET /nonexistent returns 404", async () => {
     const res = await request(app).get("/nonexistent");
     expect(res.status).toBe(404);
+  });
+});
+
+describe("API key authentication", () => {
+  const TEST_API_KEY = "test-secret-key-12345";
+  let authApp: express.Express;
+
+  beforeAll(async () => {
+    // Set env var before calling createApp() — Env.apiKey is a getter that reads
+    // process.env at call time, so createApp() will capture the key correctly.
+    process.env.FACILITATOR_API_KEY = TEST_API_KEY;
+    const mod = await import("../../src/app.js");
+    authApp = mod.createApp();
+    delete process.env.FACILITATOR_API_KEY;
+  });
+
+  it("returns 401 on /verify when no Authorization header is provided", async () => {
+    const res = await request(authApp).post("/verify").send({
+      paymentPayload: validPaymentPayload,
+      paymentRequirements: validPaymentRequirements,
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Unauthorized");
+  });
+
+  it("returns 401 on /settle when Authorization header has wrong key", async () => {
+    const res = await request(authApp)
+      .post("/settle")
+      .set("Authorization", "Bearer wrong-key")
+      .send({
+        paymentPayload: validPaymentPayload,
+        paymentRequirements: validPaymentRequirements,
+      });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 on /supported when Authorization header is missing", async () => {
+    const res = await request(authApp).get("/supported");
+    expect(res.status).toBe(401);
+  });
+
+  it("allows /verify with correct Bearer token", async () => {
+    const res = await request(authApp)
+      .post("/verify")
+      .set("Authorization", `Bearer ${TEST_API_KEY}`)
+      .send({
+        paymentPayload: validPaymentPayload,
+        paymentRequirements: validPaymentRequirements,
+      });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows /settle with correct Bearer token", async () => {
+    const res = await request(authApp)
+      .post("/settle")
+      .set("Authorization", `Bearer ${TEST_API_KEY}`)
+      .send({
+        paymentPayload: validPaymentPayload,
+        paymentRequirements: validPaymentRequirements,
+      });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows /supported with correct Bearer token", async () => {
+    const res = await request(authApp)
+      .get("/supported")
+      .set("Authorization", `Bearer ${TEST_API_KEY}`);
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects token with wrong casing of key value (case-sensitive comparison)", async () => {
+    const res = await request(authApp)
+      .post("/verify")
+      .set("Authorization", `Bearer ${TEST_API_KEY.toUpperCase()}`)
+      .send({
+        paymentPayload: validPaymentPayload,
+        paymentRequirements: validPaymentRequirements,
+      });
+    expect(res.status).toBe(401);
+  });
+
+  it("does not protect /health (always open)", async () => {
+    const res = await request(authApp).get("/health");
+    expect(res.status).toBe(200);
   });
 });

--- a/examples/simple-paywall/server/src/middleware/paymentLogger.ts
+++ b/examples/simple-paywall/server/src/middleware/paymentLogger.ts
@@ -41,10 +41,8 @@ export function paymentLogger() {
     let paymentResponseHeader: string | undefined;
     let extractedErrorFields: Record<string, string> = {};
 
-    // Intercepts res.setHeader to capture payment headers as they're set.
-    // Express's res.set() and res.header() delegate to setHeader, so those are
-    // covered. However, res.writeHead() can set headers directly — if upstream
-    // middleware ever uses writeHead, those headers won't be captured here.
+    // Intercept res.setHeader to capture payment headers set via Express's
+    // res.set() / res.header() (which both delegate to setHeader).
     res.setHeader = function (name: string, value: number | string | readonly string[]) {
       const normalizedName = name.toLowerCase();
       const normalizedValue = normalizeHeaderValue(value);
@@ -60,6 +58,32 @@ export function paymentLogger() {
       return originalSetHeader(name, value);
     };
 
+    // Also intercept res.writeHead so that headers set directly through the
+    // low-level Node.js API are captured (e.g. middleware that bypasses Express).
+    const originalWriteHead = res.writeHead.bind(res) as typeof res.writeHead;
+    res.writeHead = function (
+      statusCode: number,
+      ...args: Parameters<typeof res.writeHead> extends [number, ...infer Rest] ? Rest : never[]
+    ) {
+      // Headers may appear as the 1st extra arg (no reason phrase) or the 2nd
+      // (when a string reason phrase is provided first).
+      for (const arg of args) {
+        if (arg && typeof arg === "object" && !Array.isArray(arg)) {
+          const headers = arg as Record<string, string | number | string[]>;
+          for (const [name, value] of Object.entries(headers)) {
+            const lower = name.toLowerCase();
+            if (lower === PAYMENT_REQUIRED_HEADER && typeof value === "string") {
+              paymentRequiredHeader = value;
+            } else if (lower === PAYMENT_RESPONSE_HEADER && typeof value === "string") {
+              paymentResponseHeader = value;
+            }
+          }
+        }
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (originalWriteHead as any)(statusCode, ...args);
+    } as typeof res.writeHead;
+
     res.json = function (body: unknown) {
       if (res.statusCode >= 400) {
         extractedErrorFields = extractErrorFields(body);
@@ -69,8 +93,14 @@ export function paymentLogger() {
     };
 
     res.once("finish", () => {
-      const decodedPaymentRequired = parseX402Header(paymentRequiredHeader);
-      const decodedPaymentResponse = parseX402Header(paymentResponseHeader);
+      const onHeaderParseError = (err: unknown, raw: string) => {
+        logger.warn(
+          { err, rawHeader: raw.slice(0, 200) },
+          "Malformed x402 header — possible tampering",
+        );
+      };
+      const decodedPaymentRequired = parseX402Header(paymentRequiredHeader, onHeaderParseError);
+      const decodedPaymentResponse = parseX402Header(paymentResponseHeader, onHeaderParseError);
 
       if (res.statusCode >= 400) {
         const paymentContext =

--- a/examples/simple-paywall/server/src/middleware/txHashInjector.ts
+++ b/examples/simple-paywall/server/src/middleware/txHashInjector.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from "express";
 import { parseX402Header, type X402PaymentResponsePayload } from "@x402-stellar/shared";
+import { logger } from "../utils/logger.js";
 
 /**
  * Middleware that intercepts HTML responses carrying a PAYMENT-RESPONSE header,
@@ -106,7 +107,9 @@ export function injectTxLink(body: string, paymentResponseHeader: string | undef
     return body.replaceAll("{{TX_LINK}}", "");
   }
 
-  const decoded = parseX402Header<X402PaymentResponsePayload>(paymentResponseHeader);
+  const decoded = parseX402Header<X402PaymentResponsePayload>(paymentResponseHeader, (err, raw) => {
+    logger.warn({ err, rawHeader: raw.slice(0, 200) }, "Malformed payment-response header in txHashInjector");
+  });
   if (!decoded) {
     return body.replaceAll("{{TX_LINK}}", "");
   }

--- a/examples/simple-paywall/server/src/middleware/txHashInjector.ts
+++ b/examples/simple-paywall/server/src/middleware/txHashInjector.ts
@@ -108,7 +108,10 @@ export function injectTxLink(body: string, paymentResponseHeader: string | undef
   }
 
   const decoded = parseX402Header<X402PaymentResponsePayload>(paymentResponseHeader, (err, raw) => {
-    logger.warn({ err, rawHeader: raw.slice(0, 200) }, "Malformed payment-response header in txHashInjector");
+    logger.warn(
+      { err, rawHeader: raw.slice(0, 200) },
+      "Malformed payment-response header in txHashInjector",
+    );
   });
   if (!decoded) {
     return body.replaceAll("{{TX_LINK}}", "");

--- a/examples/simple-paywall/server/tests/middleware/paymentLogger.test.ts
+++ b/examples/simple-paywall/server/tests/middleware/paymentLogger.test.ts
@@ -41,6 +41,18 @@ function createMocks(paymentHeader: boolean, statusCode: number) {
       return res;
     }),
     getHeader: vi.fn((name: string) => headers.get(name.toLowerCase())),
+    writeHead: vi.fn((_statusCode: number, ...args: unknown[]) => {
+      for (const arg of args) {
+        if (arg && typeof arg === "object" && !Array.isArray(arg)) {
+          for (const [name, value] of Object.entries(arg as Record<string, unknown>)) {
+            if (typeof value === "string") {
+              headers.set(name.toLowerCase(), value);
+            }
+          }
+        }
+      }
+      return res;
+    }),
     once: events.once.bind(events),
   } as unknown as Response;
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
       "h3": "^1.15.9",
       "lodash": "4.18.1",
       "defu": ">=6.1.5",
-      "typescript": "^5.9.3"
+      "typescript": "^5.9.3",
+      "axios": "^1.15.0"
     }
   },
   "devDependencies": {

--- a/packages/paywall/src/browser/utils.ts
+++ b/packages/paywall/src/browser/utils.ts
@@ -55,7 +55,9 @@ export function formatPaymentError(
   paymentRequiredHeader?: string | null,
 ): string {
   const paymentRequiredError = getX402ErrorMessage(
-    parseX402Header<Record<string, unknown>>(paymentRequiredHeader),
+    parseX402Header<Record<string, unknown>>(paymentRequiredHeader, (err) => {
+      console.warn("Malformed x402 payment-required header:", err);
+    }),
   );
   if (paymentRequiredError) {
     return `${prefix}: ${paymentRequiredError}`;

--- a/packages/shared/src/x402Http.ts
+++ b/packages/shared/src/x402Http.ts
@@ -50,9 +50,12 @@ function decodeX402HeaderBase64Value(base64HeaderValue: string): string {
  * Parses a base64-encoded JSON x402 header value into a typed payload.
  *
  * Returns `undefined` when the value is absent, empty, or not valid JSON.
+ * Pass `onParseError` to surface malformed/tampered headers to callers
+ * (e.g. for logging or alerting) without interrupting the request flow.
  */
 export function parseX402Header<T = unknown>(
   x402HeaderValue: string | null | undefined,
+  onParseError?: (err: unknown, raw: string) => void,
 ): T | undefined {
   if (!x402HeaderValue) {
     return undefined;
@@ -60,7 +63,8 @@ export function parseX402Header<T = unknown>(
 
   try {
     return JSON.parse(decodeX402HeaderBase64Value(x402HeaderValue)) as T;
-  } catch {
+  } catch (err) {
+    onParseError?.(err, x402HeaderValue);
     return undefined;
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       express:
         specifier: ^5.2.1
         version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.3.2
+        version: 8.3.2(express@5.2.1)
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
@@ -3206,6 +3209,12 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.3.2:
+    resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
 
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
@@ -9197,6 +9206,11 @@ snapshots:
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.3.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.1.0
 
   express@5.2.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   lodash: 4.18.1
   defu: '>=6.1.5'
   typescript: ^5.9.3
+  axios: ^1.15.0
 
 importers:
 
@@ -2650,10 +2651,10 @@ packages:
   axios-retry@4.5.0:
     resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
     peerDependencies:
-      axios: 0.x || 1.x
+      axios: ^1.15.0
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -5240,8 +5241,8 @@ snapshots:
       '@solana/kit': 5.5.1(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@6.0.6)
       '@solana/web3.js': 1.98.4(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@6.0.6)
       abitype: 1.0.6(typescript@5.9.3)(zod@3.25.76)
-      axios: 1.14.0
-      axios-retry: 4.5.0(axios@1.14.0)
+      axios: 1.15.0
+      axios-retry: 4.5.0(axios@1.15.0)
       jose: 6.2.2
       md5: 2.3.0
       uncrypto: 0.1.3
@@ -7191,7 +7192,7 @@ snapshots:
   '@stellar/stellar-sdk@14.2.0':
     dependencies:
       '@stellar/stellar-base': 14.0.1
-      axios: 1.14.0
+      axios: 1.15.0
       bignumber.js: 9.3.1
       eventsource: 2.0.2
       feaxios: 0.0.23
@@ -7204,7 +7205,7 @@ snapshots:
   '@stellar/stellar-sdk@14.6.1':
     dependencies:
       '@stellar/stellar-base': 14.1.0
-      axios: 1.14.0
+      axios: 1.15.0
       bignumber.js: 9.3.1
       commander: 14.0.3
       eventsource: 2.0.2
@@ -7218,7 +7219,7 @@ snapshots:
   '@stellar/stellar-sdk@15.0.0':
     dependencies:
       '@stellar/stellar-base': 15.0.0
-      axios: 1.14.0
+      axios: 1.15.0
       bignumber.js: 9.3.1
       commander: 14.0.3
       eventsource: 2.0.2
@@ -8554,13 +8555,13 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios-retry@4.5.0(axios@1.14.0):
+  axios-retry@4.5.0(axios@1.15.0):
     dependencies:
-      axios: 1.14.0
+      axios: 1.15.0
       is-retry-allowed: 2.2.0
     optional: true
 
-  axios@1.14.0:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ minimumReleaseAgeExclude:
   - lodash@4.18.1 # security patch (GHSA-r5fr-rjxr-66jc): fixes _.template code injection
   - "vite@6.4.2 || 7.3.2" # security patches (GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583)
   - defu@6.1.5 # security patch (GHSA-737v-mqg7-c878): prototype pollution fix
+  - axios@1.15.0 # security patch (GHSA-jr5f-v2jv-69x6, GHSA-8hc4-xxm3-5ppp): CVE fixes in critical alerts #14 and #15
 packages:
   - examples/*/server
   - examples/*/client


### PR DESCRIPTION
## What
- Add `"axios": "^1.15.0"` to `pnpm.overrides` in `package.json` to force all transitive consumers of axios to the patched version
- Add `axios@1.15.0` to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` to bypass the 7-day release age gate (axios 1.15.0 was published 5 days ago)
- Update `pnpm-lock.yaml` — all `@stellar/stellar-sdk` snapshots (14.2.0, 14.6.1, 15.0.0) now resolve to axios 1.15.0

## Why
Dependabot raised two critical alerts (#14, #15) against `axios <1.15.0`:
- **GHSA-jr5f-v2jv-69x6**
- **GHSA-8hc4-xxm3-5ppp**

axios is a transitive dependency pulled in by `@stellar/stellar-sdk`. The latest stellar-sdk (15.0.1) still pins axios 1.14.0, so updating the direct dependency does not resolve the vulnerability. A workspace override is the least-invasive fix until stellar-sdk ships a patched release.

The remaining open alert (#1, `elliptic <=6.6.1`, low severity) has no patched version available upstream and is left unaddressed.

## Additional changes

Also closes https://github.com/stellar/internal-agents/issues/340