### PR TITLE
fix: update pnpm overrides for current CVE set

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,11 @@
   },
   "pnpm": {
     "overrides": {
-      "flatted": "^3.4.2",
-      "h3": "^1.15.9",
       "lodash": "4.18.1",
-      "defu": ">=6.1.5",
       "typescript": "^5.9.3",
-      "axios": "^1.15.0"
+      "axios": "^1.15.0",
+      "protobufjs": "^7.5.5",
+      "follow-redirects": "^1.16.0"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,12 +5,11 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  flatted: ^3.4.2
-  h3: ^1.15.9
   lodash: 4.18.1
-  defu: '>=6.1.5'
   typescript: ^5.9.3
   axios: ^1.15.0
+  protobufjs: ^7.5.5
+  follow-redirects: ^1.16.0
 
 importers:
 
@@ -3289,8 +3288,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -4120,8 +4119,8 @@ packages:
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
 
-  protobufjs@7.4.0:
-    resolution: {integrity: sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==}
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -7524,14 +7523,14 @@ snapshots:
     dependencies:
       '@trezor/schema-utils': 1.4.0(tslib@2.8.1)
       long: 5.2.5
-      protobufjs: 7.4.0
+      protobufjs: 7.5.5
       tslib: 2.8.1
 
   '@trezor/protobuf@1.5.2(tslib@2.8.1)':
     dependencies:
       '@trezor/schema-utils': 1.4.0(tslib@2.8.1)
       long: 5.2.5
-      protobufjs: 7.4.0
+      protobufjs: 7.5.5
       tslib: 2.8.1
 
   '@trezor/protocol@1.3.0(tslib@2.8.1)':
@@ -8572,7 +8571,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -9311,7 +9310,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   for-each@0.3.5:
     dependencies:
@@ -10158,7 +10157,7 @@ snapshots:
 
   process-warning@5.0.0: {}
 
-  protobufjs@7.4.0:
+  protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,9 @@ minimumReleaseAge: 10080 # 7 days, in minutes
 minimumReleaseAgeExclude:
   - lodash@4.18.1 # security patch (GHSA-r5fr-rjxr-66jc): fixes _.template code injection
   - "vite@6.4.2 || 7.3.2" # security patches (GHSA-v2wj-q39q-566r, GHSA-p9ff-h696-f583)
-  - defu@6.1.5 # security patch (GHSA-737v-mqg7-c878): prototype pollution fix
   - axios@1.15.0 # security patch (GHSA-jr5f-v2jv-69x6, GHSA-8hc4-xxm3-5ppp): CVE fixes in critical alerts #14 and #15
+  - protobufjs@7.5.5 # security patch (GHSA-xq3m-2v4x-88gg): arbitrary code execution fix in critical alert #17
+  - follow-redirects@1.16.0 # security patch (GHSA-cxjh-pqwp-8mfp): fix in medium alert #16
 packages:
   - examples/*/server
   - examples/*/client


### PR DESCRIPTION
## What

**Added** overrides for 2 Dependabot alerts:
- `protobufjs ^7.5.5` — critical ([alert #17](https://github.com/stellar/x402-stellar/security/dependabot/17))
- `follow-redirects ^1.16.0` — medium ([alert #16](https://github.com/stellar/x402-stellar/security/dependabot/16))

**Removed** 3 orphaned overrides (parents now resolve to patched versions naturally):
- `flatted`, `h3`, `defu`

Also dropped the paired `defu@6.1.5` entry from `minimumReleaseAgeExclude`.

## Verification
- `pnpm audit --audit-level moderate` → 0 findings
- `make typecheck test build` → pass

Low-severity `elliptic` alert skipped — no patched version published.
