### PR TITLE
fix: override form-data to ^4.0.6 (GHSA-hmw2-7cc7-3qxx)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "overrides": {
       "typescript": "^5.9.3",
       "axios": "^1.16.1",
+      "form-data": "^4.0.6",
       "protobufjs": "^7.5.6",
       "uuid": "^14.0.0",
       "ws@8": "^8.21.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   typescript: ^5.9.3
   axios: ^1.16.1
+  form-data: ^4.0.6
   protobufjs: ^7.5.6
   uuid: ^14.0.0
   ws@8: ^8.21.0
@@ -3349,8 +3350,8 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   formidable@3.5.4:
@@ -7654,7 +7655,7 @@ snapshots:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
       '@types/node': 25.9.1
-      form-data: 4.0.5
+      form-data: 4.0.6
 
   '@types/supertest@7.2.0':
     dependencies:
@@ -8503,7 +8504,7 @@ snapshots:
   axios@1.16.1:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -9236,7 +9237,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -10509,7 +10510,7 @@ snapshots:
       cookiejar: 2.1.4
       debug: 4.4.3
       fast-safe-stringify: 2.1.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0


### PR DESCRIPTION
## What

Pin `form-data` to `^4.0.6` via a pnpm override.

## Why

The high-severity `form-data` CRLF-injection advisory ([GHSA-hmw2-7cc7-3qxx](https://github.com/advisories/GHSA-hmw2-7cc7-3qxx), patched in `>=4.0.6`) was published **after** main last passed CI. As a result, `pnpm audit --audit-level high` now fails on the transitive path:

```
@stellar/stellar-sdk > axios > form-data@4.0.5
```

This blocks the Audit step of the Check workflow on every PR/push (surfaced while unblocking #65). The fix follows the existing `pnpm.overrides` convention (see #59/#60/#62).

## Verification

```
$ pnpm audit --audit-level high
4 vulnerabilities found
Severity: 3 low | 1 moderate   # exit 0 — high resolved
```

Lockfile now resolves `form-data@4.0.6`. No other dependencies changed.