### PR TITLE
Migrate x402-stellar service builds to github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Slack notification — success
         if: success()
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:
@@ -65,7 +65,7 @@ jobs:
 
       - name: Slack notification — failure
         if: failure()
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,73 @@
+name: Build and push x402-stellar
+
+# Deployed to: https://github.com/stellar/x402-stellar
+#
+# Converted from the Jenkins pipeline (Jenkinsfile). On every push to main
+# (or manual dispatch) builds the x402-stellar server and client docker images
+# and pushes them to the prd ECR repos. Production deploys require manual
+# approval, enforced by the `production` environment's required reviewers.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env:
+  APP_NAME: x402-stellar
+  SLACK_CHANNEL: alerts-devx
+  CLIENT_URL: https://stellar.org/x402-demo
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    # Gates production deploys on manual approval (Jenkins "Deploy to production?" input).
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine image label
+        id: vars
+        run: echo "label=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: ECR login
+        id: ecr-login
+        uses: stellar/actions/sdf-ecr-login@main
+
+      - name: Build and push docker images
+        env:
+          ECR_REGISTRY: ${{ steps.ecr-login.outputs.ecr-registry }}
+          LABEL: ${{ steps.vars.outputs.label }}
+        run: |
+          set -eu
+          export SERVER_TAG="${ECR_REGISTRY}/prd/${APP_NAME}-server:${LABEL}"
+          export CLIENT_TAG="${ECR_REGISTRY}/prd/${APP_NAME}-client:${LABEL}"
+
+          make docker-build-server
+          make docker-build-client
+
+          ecr-push "${SERVER_TAG}"
+          ecr-push "${CLIENT_TAG}"
+
+      - name: Slack notification — success
+        if: success()
+        uses: slackapi/slack-github-action@v1.27.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL }}
+          slack-message: "${{ env.APP_NAME }} *prd* build complete for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}. ${{ env.APP_NAME }} available at ${{ env.CLIENT_URL }}."
+
+      - name: Slack notification — failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.27.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: ${{ env.SLACK_CHANNEL }}
+          slack-message: "${{ env.APP_NAME }} *prd* build failed for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,18 +56,20 @@ jobs:
 
       - name: Slack notification — success
         if: success()
-        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          channel-id: ${{ env.SLACK_CHANNEL }}
-          slack-message: "${{ env.APP_NAME }} *prd* build complete for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}. ${{ env.APP_NAME }} available at ${{ env.CLIENT_URL }}."
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ env.SLACK_CHANNEL }}
+            text: "Build complete. Repository: ${{ github.server_url }}/${{ github.repository }} Commit: ${{ github.sha }}."
 
       - name: Slack notification — failure
         if: failure()
-        uses: slackapi/slack-github-action@fcfb566f8b0aab22203f066d80ca1d7e4b5d05b3 # v1.27.1
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
-          channel-id: ${{ env.SLACK_CHANNEL }}
-          slack-message: "${{ env.APP_NAME }} *prd* build failed for ${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}."
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ env.SLACK_CHANNEL }}
+            text: "Build failed. Repository: ${{ github.server_url }}/${{ github.repository }} Commit: ${{ github.sha }}."


### PR DESCRIPTION
### What:

Migrate x402-stellar service builds to github actions

### Why:

We are moving builds to Github actions.

### Issue:

https://github.com/stellar/ops/issues/4718