### PR TITLE
fix(paywall): make the trustline banner actionable, and fix its link

### DIFF
--- a/packages/paywall/src/browser/StellarPaywall.tsx
+++ b/packages/paywall/src/browser/StellarPaywall.tsx
@@ -3,6 +3,7 @@ import type { PaymentRequired, PaymentRequirements } from "@x402/core/types";
 import { getNetworkDisplayName } from "./utils";
 import { Spinner } from "./Spinner";
 import { statusError, statusInfo, type Status } from "./status";
+import { useAddTrustline } from "./useAddTrustline";
 import { useStellarBalance } from "./useStellarBalance";
 import { useStellarPayment } from "./useStellarPayment";
 import { useSWKConnection } from "./useSWKConnection";
@@ -20,6 +21,13 @@ type StellarPaywallMainProps = {
 };
 
 const STELLAR_PAYMENT_SCALE = 10_000_000;
+
+/**
+ * Lab's transaction builder, where a `change_trust` operation can be assembled.
+ * `/account/fund` — where this used to point — is the friendbot XLM funding
+ * page and has nothing to do with trustlines.
+ */
+const STELLAR_LAB_BUILD_TX_URL = "https://lab.stellar.org/transaction/build";
 
 /**
  * Paywall experience for Stellar networks. Validates that a Stellar payment
@@ -101,6 +109,14 @@ function StellarPaywallMain({
     network,
     asset,
     onStatus: setStatus,
+  });
+
+  const { isAddingTrustline, addTrustline } = useAddTrustline({
+    address,
+    network,
+    assetMetadata,
+    onStatus: setStatus,
+    onAdded: refreshBalance,
   });
 
   const walletSigner = useSWKSigner({
@@ -270,17 +286,28 @@ function StellarPaywallMain({
               </p>
               <p className="trustline-text">
                 Your account needs a <strong>{assetMetadata ? assetMetadata.code : "asset"}</strong>{" "}
-                trustline before you can hold or pay with this asset. Add one via{" "}
-                <a
-                  href="https://lab.stellar.org/account/fund"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Stellar Laboratory
-                </a>
-                : connect your wallet, add the {assetMetadata ? assetMetadata.code : "asset"}{" "}
-                trustline, and sign the transaction.
+                trustline before you can hold or pay with this asset.{" "}
+                {addTrustline ? (
+                  <>Add it with the wallet you already connected.</>
+                ) : (
+                  <>
+                    Build a <code>change_trust</code> operation in{" "}
+                    <a href={STELLAR_LAB_BUILD_TX_URL} target="_blank" rel="noopener noreferrer">
+                      Stellar Laboratory
+                    </a>
+                    , then sign and submit it.
+                  </>
+                )}
               </p>
+              {addTrustline && (
+                <button
+                  className="button button-secondary trustline-action"
+                  onClick={() => void addTrustline()}
+                  disabled={isAddingTrustline}
+                >
+                  {isAddingTrustline ? <Spinner /> : `Add ${assetMetadata?.code} trustline`}
+                </button>
+              )}
             </div>
           </div>
         )}

--- a/packages/paywall/src/browser/styles.css
+++ b/packages/paywall/src/browser/styles.css
@@ -359,3 +359,23 @@ body {
 .trustline-text a:hover {
   color: #4e2009;
 }
+
+.trustline-action {
+  margin-top: 0.625rem;
+  width: auto;
+  background-color: #ffffff;
+  border: 1px solid #ffb224;
+  color: #4e2009;
+}
+
+.trustline-action:hover:not(:disabled) {
+  background-color: #fdf0d5;
+}
+
+.trustline-text code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.75rem;
+  padding: 0.0625rem 0.25rem;
+  border-radius: 0.1875rem;
+  background-color: rgba(173, 87, 0, 0.12);
+}

--- a/packages/paywall/src/browser/useAddTrustline.ts
+++ b/packages/paywall/src/browser/useAddTrustline.ts
@@ -1,0 +1,140 @@
+import { useCallback, useState } from "react";
+import { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit/sdk";
+import { Asset, BASE_FEE, Operation, TransactionBuilder } from "@stellar/stellar-sdk";
+import { Server } from "@stellar/stellar-sdk/rpc";
+import type { Network } from "@x402/core/types";
+import { getNetworkPassphrase, getRpcUrl } from "@x402/stellar";
+import { parseError } from "@x402-stellar/shared";
+import { statusError, statusInfo, statusSuccess, type Status } from "./status";
+import type { AssetMetadata } from "./useStellarBalance";
+
+/** How long to wait for the trustline transaction to leave the pending state. */
+const CONFIRMATION_TIMEOUT_MS = 30_000;
+const CONFIRMATION_POLL_INTERVAL_MS = 1_000;
+
+export type UseAddTrustlineParams = {
+  address: string | null;
+  network: Network;
+  assetMetadata: AssetMetadata | null;
+  onStatus: (status: Status | null) => void;
+  onAdded: () => void;
+};
+
+export type UseAddTrustlineReturn = {
+  isAddingTrustline: boolean;
+  /** `null` when the paywall does not have everything it needs to offer the action. */
+  addTrustline: (() => Promise<void>) | null;
+};
+
+/**
+ * Adds the trustline the payment asset requires, signing with the wallet that
+ * is already connected to the paywall.
+ *
+ * Without a trustline the account cannot hold the asset at all, so the paywall
+ * is otherwise a dead end: the Pay button is disabled and the only way forward
+ * is to leave, add the trustline elsewhere, and come back.
+ *
+ * @param params - Hook parameters.
+ * @param params.address - Connected wallet address that will hold the trustline.
+ * @param params.network - Network to submit on (CAIP-2 format).
+ * @param params.assetMetadata - Asset code and issuer, read from the SAC.
+ * @param params.onStatus - Callback for status messages.
+ * @param params.onAdded - Invoked once the trustline is confirmed on-ledger.
+ * @returns The submit handler, or `null` when the action cannot be offered.
+ */
+export function useAddTrustline({
+  address,
+  network,
+  assetMetadata,
+  onStatus,
+  onAdded,
+}: UseAddTrustlineParams): UseAddTrustlineReturn {
+  const [isAddingTrustline, setIsAddingTrustline] = useState(false);
+  const runtimeRpcUrl = window.x402?.config?.rpcUrl;
+
+  const addTrustline = useCallback(async () => {
+    if (!address || !assetMetadata) {
+      return;
+    }
+
+    setIsAddingTrustline(true);
+    try {
+      const networkPassphrase = getNetworkPassphrase(network);
+      const server = new Server(getRpcUrl(network, { url: runtimeRpcUrl }));
+
+      onStatus(statusInfo(`Building ${assetMetadata.code} trustline...`));
+      const account = await server.getAccount(address);
+
+      const transaction = new TransactionBuilder(account, {
+        fee: BASE_FEE,
+        networkPassphrase,
+      })
+        .addOperation(
+          Operation.changeTrust({
+            asset: new Asset(assetMetadata.code, assetMetadata.issuer),
+          }),
+        )
+        .setTimeout(180)
+        .build();
+
+      onStatus(statusInfo("Waiting for user signature..."));
+      const { signedTxXdr } = await StellarWalletsKit.signTransaction(transaction.toXDR(), {
+        address,
+        networkPassphrase,
+      });
+
+      if (!signedTxXdr) {
+        throw new Error("Wallet did not return a signed transaction.");
+      }
+
+      onStatus(statusInfo("Submitting trustline..."));
+      const signed = TransactionBuilder.fromXDR(signedTxXdr, networkPassphrase);
+      const sent = await server.sendTransaction(signed);
+
+      if (sent.status === "ERROR") {
+        throw new Error(
+          `Trustline transaction was rejected by the network (${sent.errorResult?.result().switch().name ?? "unknown reason"}).`,
+        );
+      }
+
+      await waitForTransaction(server, sent.hash);
+
+      onStatus(statusSuccess(`${assetMetadata.code} trustline added.`));
+      onAdded();
+    } catch (error) {
+      console.error("Failed to add trustline", error);
+      onStatus(statusError(parseError(error, "Failed to add the trustline.")));
+    } finally {
+      setIsAddingTrustline(false);
+    }
+  }, [address, assetMetadata, network, onStatus, onAdded, runtimeRpcUrl]);
+
+  return {
+    isAddingTrustline,
+    // Both the wallet and the asset identity are required; without either there
+    // is nothing to sign or nothing to trust.
+    addTrustline: address && assetMetadata ? addTrustline : null,
+  };
+}
+
+/**
+ * Polls until the transaction leaves `NOT_FOUND`, then throws unless it succeeded.
+ */
+async function waitForTransaction(server: Server, hash: string): Promise<void> {
+  const deadline = Date.now() + CONFIRMATION_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    const result = await server.getTransaction(hash);
+
+    if (result.status === "SUCCESS") {
+      return;
+    }
+    if (result.status === "FAILED") {
+      throw new Error("Trustline transaction failed on-ledger.");
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, CONFIRMATION_POLL_INTERVAL_MS));
+  }
+
+  throw new Error("Timed out waiting for the trustline transaction to confirm.");
+}


### PR DESCRIPTION
# fix(paywall): add the missing trustline from the paywall, and fix the link

**Branch:** `fix/paywall-trustline-link`
**Screenshots:** `harness/shots/before-missing-trustline.png` → `harness/shots/after-missing-trustline.png`

## The problem

When the payer's account has no trustline for the payment asset, the paywall
disables Pay and shows a banner pointing at:

```
https://lab.stellar.org/account/fund
```

That is Lab's friendbot **account funding** page. It has nothing to do with
trustlines, and friendbot does not exist on mainnet. The banner's own text says
"add the USDC trustline" — but the link does not lead anywhere that can do it.
The payer has to work out on their own that they need a `change_trust`
operation, build it elsewhere, and come back.

## The change

The wallet that can sign that operation is already connected to the paywall, so
offer the action directly:

- New `useAddTrustline` builds a `change_trust` for the asset read off the SAC,
  signs it with the connected wallet through `signTransaction`, submits it,
  waits for confirmation, then re-reads the balance. The banner clears itself
  and Pay becomes available without leaving the page.
- The Lab link stays as the fallback for when the asset's code/issuer could not
  be read, and now points at `/transaction/build`, where a `change_trust`
  operation can actually be assembled.

## Cost

~2 KB on the bundle (3,749,116 → 3,751,075 bytes). `Asset`, `Operation`,
`TransactionBuilder` and `rpc.Server` all come from `@stellar/stellar-sdk`,
which the paywall already bundles for the balance read.

## Failure paths

Each produces a distinct message on the existing status line: rejected
signature, network rejection (`sendTransaction` → `ERROR`), on-ledger failure
(`getTransaction` → `FAILED`), and a 30s confirmation timeout.

## Notes

Happy to split this into two PRs — the one-line link fix, and the in-paywall
trustline flow — if you would rather take them separately.

---

Part of #74.
