### PR TITLE
feat(paywall): show a receipt for the settled payment before loading the content

### DIFF
--- a/packages/paywall/src/browser/StellarPaywall.tsx
+++ b/packages/paywall/src/browser/StellarPaywall.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { PaymentRequired, PaymentRequirements } from "@x402/core/types";
-import { getNetworkDisplayName } from "./utils";
+import { formatDuration, getExplorerTxUrl, getNetworkDisplayName, truncateHash } from "./utils";
 import { Spinner } from "./Spinner";
 import { statusError, statusInfo, type Status } from "./status";
 import { useStellarBalance } from "./useStellarBalance";
-import { useStellarPayment } from "./useStellarPayment";
+import { useStellarPayment, type PaymentReceipt } from "./useStellarPayment";
 import { useSWKConnection } from "./useSWKConnection";
 import { useSWKSigner } from "./useSWKSigner";
 
@@ -20,6 +20,14 @@ type StellarPaywallMainProps = {
 };
 
 const STELLAR_PAYMENT_SCALE = 10_000_000;
+
+/**
+ * How long the receipt stays up before the paid content takes over. The paid
+ * response usually replaces the whole document, so without this pause the payer
+ * never sees what they paid or the hash it settled under. Hosts can override it
+ * with `receiptDelayMs`; `0` skips the receipt entirely and hands off at once.
+ */
+const DEFAULT_RECEIPT_DELAY_MS = 3000;
 
 /**
  * Paywall experience for Stellar networks. Validates that a Stellar payment
@@ -75,6 +83,9 @@ function StellarPaywallMain({
 }: StellarPaywallMainProps) {
   const [status, setStatus] = useState<Status | null>(null);
   const [hideBalance, setHideBalance] = useState(true);
+  const [receipt, setReceipt] = useState<PaymentReceipt | null>(null);
+  // Resolves the promise `onReceipt` returns, releasing the paid content.
+  const continueRef = useRef<(() => void) | null>(null);
 
   const x402 = window.x402;
   const { network, asset } = stellarRequirement;
@@ -109,11 +120,42 @@ function StellarPaywallMain({
     address,
   });
 
+  const receiptDelayMs = x402.config?.receiptDelayMs ?? DEFAULT_RECEIPT_DELAY_MS;
+
+  const handleReceipt = useCallback(
+    (settled: PaymentReceipt) => {
+      if (receiptDelayMs <= 0) {
+        return;
+      }
+
+      setReceipt(settled);
+
+      return new Promise<void>((resolve) => {
+        const timer = window.setTimeout(() => {
+          continueRef.current = null;
+          resolve();
+        }, receiptDelayMs);
+
+        continueRef.current = () => {
+          window.clearTimeout(timer);
+          continueRef.current = null;
+          resolve();
+        };
+      });
+    },
+    [receiptDelayMs],
+  );
+
+  // A pending hand-off must never outlive the component, or the paid content
+  // would never load.
+  useEffect(() => () => continueRef.current?.(), []);
+
   const { isPaying, submitPayment } = useStellarPayment({
     paymentRequired,
     walletSigner,
     onSuccessfulResponse,
     setStatus,
+    onReceipt: handleReceipt,
   });
 
   const amount =
@@ -176,6 +218,73 @@ function StellarPaywallMain({
     refreshBalance,
     submitPayment,
   ]);
+
+  if (receipt) {
+    // Prefer the network the facilitator reported, but fall back to the one the
+    // requirement named — facilitators are not guaranteed to report it in CAIP-2
+    // form, and losing the explorer link over that would defeat the receipt.
+    const explorerUrl =
+      getExplorerTxUrl(receipt.network, receipt.transaction) ??
+      getExplorerTxUrl(network, receipt.transaction);
+
+    return (
+      <div className="container gap-8">
+        <div className="header">
+          <h1 className="title">Payment Settled</h1>
+          <p>
+            Paid ${amount} {assetCode} on {chainName}. Loading the content you paid for…
+          </p>
+        </div>
+
+        <div className="content w-full">
+          <div className="payment-details">
+            <div className="payment-row">
+              <span className="payment-label">Amount:</span>
+              <span className="payment-value">
+                ${amount} {assetCode}
+              </span>
+            </div>
+            <div className="payment-row">
+              <span className="payment-label">Paid to:</span>
+              <span className="payment-value receipt-mono">
+                {truncateHash(stellarRequirement.payTo, 6)}
+              </span>
+            </div>
+            <div className="payment-row">
+              <span className="payment-label">Transaction:</span>
+              <span className="payment-value receipt-mono">
+                {receipt.transaction ? (
+                  explorerUrl ? (
+                    <a href={explorerUrl} target="_blank" rel="noopener noreferrer">
+                      {truncateHash(receipt.transaction)} ↗
+                    </a>
+                  ) : (
+                    truncateHash(receipt.transaction)
+                  )
+                ) : (
+                  "not reported"
+                )}
+              </span>
+            </div>
+            <div className="payment-row">
+              <span className="payment-label">Settled in:</span>
+              <span className="payment-value">{formatDuration(receipt.settlementMs)}</span>
+            </div>
+          </div>
+
+          <div className="cta-container">
+            <button
+              className="button button-primary"
+              onClick={() => continueRef.current?.()}
+              autoFocus
+            >
+              Continue →
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="container gap-8">

--- a/packages/paywall/src/browser/styles.css
+++ b/packages/paywall/src/browser/styles.css
@@ -244,6 +244,20 @@ body {
   display: none;
 }
 
+.receipt-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.8125rem;
+}
+
+.receipt-mono a {
+  color: var(--button-primary-color);
+  text-decoration: none;
+}
+
+.receipt-mono a:hover {
+  text-decoration: underline;
+}
+
 .status {
   text-align: center;
   font-size: 0.875rem;

--- a/packages/paywall/src/browser/useStellarPayment.ts
+++ b/packages/paywall/src/browser/useStellarPayment.ts
@@ -4,15 +4,33 @@ import { x402Client } from "@x402/core/client";
 import { decodePaymentRequiredHeader, encodePaymentSignatureHeader } from "@x402/core/http";
 import type { ClientStellarSigner } from "@x402/stellar";
 import type { PaymentRequired } from "@x402/core/types";
-import { parseError } from "@x402-stellar/shared";
+import { parseError, parseX402Header, type X402PaymentResponsePayload } from "@x402-stellar/shared";
 import { statusError, statusInfo, statusSuccess, type Status } from "./status";
 import { formatPaymentError } from "./utils";
+
+/** What the payer gets to see once settlement succeeds. */
+export type PaymentReceipt = {
+  /** Settled transaction hash, when the facilitator reported one. */
+  transaction?: string;
+  /** Network the payment settled on, as reported by the facilitator. */
+  network?: string;
+  /** Wall-clock time from submitting the signed payment to the paid response. */
+  settlementMs: number;
+};
 
 export type UseStellarPaymentParams = {
   paymentRequired: PaymentRequired;
   walletSigner: ClientStellarSigner | null;
   setStatus: (status: Status | null) => void;
   onSuccessfulResponse: (response: Response) => Promise<void>;
+  /**
+   * Invoked with the receipt once settlement succeeds, before the paid response
+   * is handed to `onSuccessfulResponse`. Awaited, so a caller that wants to show
+   * the receipt can hold the hand-off until the payer has seen it — otherwise
+   * the paid content replaces the page immediately and the receipt is never
+   * rendered.
+   */
+  onReceipt?: (receipt: PaymentReceipt) => void | Promise<void>;
 };
 
 export type UseStellarPaymentResult = {
@@ -37,7 +55,7 @@ type X402Runtime = {
  * @returns Handlers to trigger payments and the current loading state.
  */
 export function useStellarPayment(params: UseStellarPaymentParams): UseStellarPaymentResult {
-  const { walletSigner, paymentRequired, onSuccessfulResponse, setStatus } = params;
+  const { walletSigner, paymentRequired, onSuccessfulResponse, setStatus, onReceipt } = params;
   const [isPaying, setIsPaying] = useState(false);
   const inFlightRef = useRef(false);
 
@@ -53,6 +71,30 @@ export function useStellarPayment(params: UseStellarPaymentParams): UseStellarPa
 
     inFlightRef.current = true;
     setIsPaying(true);
+
+    /**
+     * Reports the receipt for a settled response, then hands the response off.
+     * `onReceipt` is awaited so the caller can hold the hand-off — the paid
+     * content typically replaces the whole page.
+     */
+    const completePayment = async (response: Response, submittedAt: number) => {
+      setStatus(statusSuccess("Payment successful! Loading content..."));
+
+      if (onReceipt) {
+        const settled = parseX402Header<X402PaymentResponsePayload>(
+          response.headers.get("PAYMENT-RESPONSE"),
+          (err) => console.warn("Malformed x402 payment-response header:", err),
+        );
+        await onReceipt({
+          transaction: settled?.transaction,
+          network: settled?.network,
+          settlementMs: performance.now() - submittedAt,
+        });
+      }
+
+      await onSuccessfulResponse(response);
+    };
+
     try {
       setStatus(statusInfo("Waiting for user signature..."));
 
@@ -65,6 +107,7 @@ export function useStellarPayment(params: UseStellarPaymentParams): UseStellarPa
 
       setStatus(statusInfo("Settling payment..."));
       const targetUrl = window.location.href;
+      const submittedAt = performance.now();
       const response = await fetch(targetUrl, {
         headers: {
           "PAYMENT-SIGNATURE": paymentHeader,
@@ -72,8 +115,7 @@ export function useStellarPayment(params: UseStellarPaymentParams): UseStellarPa
       });
 
       if (response.ok) {
-        setStatus(statusSuccess("Payment successful! Loading content..."));
-        await onSuccessfulResponse(response);
+        await completePayment(response, submittedAt);
         return;
       }
 
@@ -114,6 +156,7 @@ export function useStellarPayment(params: UseStellarPaymentParams): UseStellarPa
             );
           }
 
+          const retrySubmittedAt = performance.now();
           const retryResponse = await fetch(targetUrl, {
             headers: {
               "PAYMENT-SIGNATURE": paymentHeader,
@@ -121,8 +164,7 @@ export function useStellarPayment(params: UseStellarPaymentParams): UseStellarPa
           });
 
           if (retryResponse.ok) {
-            setStatus(statusSuccess("Payment successful! Loading content..."));
-            await onSuccessfulResponse(retryResponse);
+            await completePayment(retryResponse, retrySubmittedAt);
             return;
           }
 
@@ -161,7 +203,15 @@ export function useStellarPayment(params: UseStellarPaymentParams): UseStellarPa
       inFlightRef.current = false;
       setIsPaying(false);
     }
-  }, [walletSigner, x402, paymentRequired, onSuccessfulResponse, setStatus, runtimeRpcUrl]);
+  }, [
+    walletSigner,
+    x402,
+    paymentRequired,
+    onSuccessfulResponse,
+    setStatus,
+    runtimeRpcUrl,
+    onReceipt,
+  ]);
 
   return { isPaying, submitPayment };
 }

--- a/packages/paywall/src/browser/utils.test.ts
+++ b/packages/paywall/src/browser/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, mock } from "node:test";
 import assert from "node:assert/strict";
-import { formatPaymentError } from "./utils.ts";
+import { formatDuration, formatPaymentError, getExplorerTxUrl, truncateHash } from "./utils.ts";
 
 describe("formatPaymentError", () => {
   it("returns status code when body is empty", () => {
@@ -137,5 +137,73 @@ describe("formatPaymentError", () => {
       formatPaymentError("Payment request rejected", 403, body),
       "Payment request rejected: timeout",
     );
+  });
+});
+
+describe("getExplorerTxUrl", () => {
+  const hash = "c1acc578032a3a06a88603f971d871703f45b1246e0f1aa8862500495edbfba6";
+
+  it("builds a testnet explorer URL", () => {
+    assert.equal(
+      getExplorerTxUrl("stellar:testnet", hash),
+      `https://stellar.expert/explorer/testnet/tx/${hash}`,
+    );
+  });
+
+  it("maps the CAIP-2 pubnet reference onto Stellar Expert's `public`", () => {
+    assert.equal(
+      getExplorerTxUrl("stellar:pubnet", hash),
+      `https://stellar.expert/explorer/public/tx/${hash}`,
+    );
+  });
+
+  it("returns null when either input is missing", () => {
+    assert.equal(getExplorerTxUrl(undefined, hash), null);
+    assert.equal(getExplorerTxUrl("stellar:testnet", undefined), null);
+  });
+
+  it("returns null for a non-Stellar network", () => {
+    assert.equal(getExplorerTxUrl("eip155:8453", hash), null);
+  });
+
+  it("returns null when the network has no reference", () => {
+    assert.equal(getExplorerTxUrl("stellar:", hash), null);
+  });
+
+  it("escapes a hash that would otherwise alter the path", () => {
+    assert.equal(
+      getExplorerTxUrl("stellar:testnet", "../../evil"),
+      "https://stellar.expert/explorer/testnet/tx/..%2F..%2Fevil",
+    );
+  });
+});
+
+describe("truncateHash", () => {
+  it("keeps both ends of a long hash", () => {
+    assert.equal(truncateHash("0123456789abcdef0123456789abcdef"), "01234567…89abcdef");
+  });
+
+  it("leaves a short value untouched", () => {
+    assert.equal(truncateHash("abcdef"), "abcdef");
+  });
+
+  it("honours a custom edge width", () => {
+    assert.equal(truncateHash("0123456789abcdef", 4), "0123…cdef");
+  });
+});
+
+describe("formatDuration", () => {
+  it("uses milliseconds below a second", () => {
+    assert.equal(formatDuration(820.4), "820ms");
+  });
+
+  it("uses seconds at and above a second", () => {
+    assert.equal(formatDuration(1000), "1.0s");
+    assert.equal(formatDuration(4137), "4.1s");
+  });
+
+  it("renders a placeholder for values that are not real durations", () => {
+    assert.equal(formatDuration(Number.NaN), "—");
+    assert.equal(formatDuration(-1), "—");
   });
 });

--- a/packages/paywall/src/browser/utils.ts
+++ b/packages/paywall/src/browser/utils.ts
@@ -48,6 +48,62 @@ export function formatUnits(value: bigint, decimals: number): string {
   return isNegative ? `-${result}` : result;
 }
 
+/**
+ * Builds the Stellar Expert URL for a settled transaction.
+ *
+ * Stellar Expert names the public network `public`, while x402 uses the CAIP-2
+ * reference `pubnet`; everything else maps straight through.
+ *
+ * @param network - CAIP-2 network id, e.g. "stellar:testnet".
+ * @param transactionHash - Hash of the settled transaction.
+ * @returns An explorer URL, or `null` when either input is missing or the
+ * network is not a Stellar one.
+ */
+export function getExplorerTxUrl(
+  network: string | undefined,
+  transactionHash: string | undefined,
+): string | null {
+  if (!network || !transactionHash || !network.startsWith("stellar:")) {
+    return null;
+  }
+
+  const reference = network.split(":")[1];
+  if (!reference) {
+    return null;
+  }
+
+  const explorerNetwork = reference === "pubnet" ? "public" : reference;
+  return `https://stellar.expert/explorer/${explorerNetwork}/tx/${encodeURIComponent(transactionHash)}`;
+}
+
+/**
+ * Shortens a hash for display, keeping enough of both ends to compare against
+ * an explorer by eye.
+ *
+ * @param value - The hash to shorten.
+ * @param edge - Characters to keep at each end.
+ * @returns The shortened hash, or the original when it is already short enough.
+ */
+export function truncateHash(value: string, edge = 8): string {
+  if (value.length <= edge * 2 + 1) {
+    return value;
+  }
+  return `${value.slice(0, edge)}…${value.slice(-edge)}`;
+}
+
+/**
+ * Formats a duration in milliseconds for the payment receipt.
+ *
+ * @param ms - Elapsed milliseconds.
+ * @returns A short human-readable duration, e.g. "820ms" or "4.1s".
+ */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) {
+    return "—";
+  }
+  return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
 export function formatPaymentError(
   prefix: string,
   status: number,

--- a/packages/paywall/src/browser/window.d.ts
+++ b/packages/paywall/src/browser/window.d.ts
@@ -11,6 +11,11 @@ declare global {
       appLogo?: string;
       config: {
         rpcUrl?: string;
+        /**
+         * How long the payment receipt stays up before the paid content is
+         * loaded. `0` skips the receipt and hands off immediately.
+         */
+        receiptDelayMs?: number;
         chainConfig: Record<
           string,
           {

--- a/packages/paywall/src/stellar-handler.ts
+++ b/packages/paywall/src/stellar-handler.ts
@@ -24,6 +24,7 @@ interface StellarPaywallOptions {
   appName?: string;
   appLogo?: string;
   stellarRpcUrl?: string;
+  stellarReceiptDelayMs?: number;
 }
 
 /**
@@ -41,7 +42,16 @@ function getStellarPaywallHtml(options: StellarPaywallOptions): string {
   if (!STELLAR_PAYWALL_TEMPLATE) {
     return `<!DOCTYPE html><html><body><h1>Stellar Paywall template not available</h1></body></html>`;
   }
-  const { amount, testnet, paymentRequired, currentUrl, appName, appLogo, stellarRpcUrl } = options;
+  const {
+    amount,
+    testnet,
+    paymentRequired,
+    currentUrl,
+    appName,
+    appLogo,
+    stellarRpcUrl,
+    stellarReceiptDelayMs,
+  } = options;
 
   const logOnTestnet = testnet
     ? "console.log('Stellar Payment required initialized:', window.x402);"
@@ -51,6 +61,10 @@ function getStellarPaywallHtml(options: StellarPaywallOptions): string {
 
   const currentUrlLine = currentUrl ? `\n      currentUrl: ${jsonForScript(currentUrl)},` : "";
   const rpcUrlLine = stellarRpcUrl ? `\n        rpcUrl: ${jsonForScript(stellarRpcUrl)},` : "";
+  const receiptDelayLine =
+    typeof stellarReceiptDelayMs === "number"
+      ? `\n        receiptDelayMs: ${jsonForScript(stellarReceiptDelayMs)},`
+      : "";
 
   const configScript = `
   <script>
@@ -58,7 +72,7 @@ function getStellarPaywallHtml(options: StellarPaywallOptions): string {
       amount: ${amount},
       paymentRequired: ${jsonForScript(paymentRequired)},
       testnet: ${testnet},${currentUrlLine}
-      config: {${rpcUrlLine}
+      config: {${rpcUrlLine}${receiptDelayLine}
         chainConfig: ${jsonForScript(config)},
       },
       appName: ${jsonForScript(appName || "")},
@@ -107,6 +121,7 @@ export const stellarPaywall: PaywallNetworkHandler = {
       appName: config.appName,
       appLogo: config.appLogo,
       stellarRpcUrl: config.stellarRpcUrl,
+      stellarReceiptDelayMs: config.stellarReceiptDelayMs,
     });
   },
 };

--- a/packages/paywall/src/types.ts
+++ b/packages/paywall/src/types.ts
@@ -12,6 +12,11 @@ export interface PaywallConfig {
   currentUrl?: string;
   testnet?: boolean;
   stellarRpcUrl?: string;
+  /**
+   * How long the Stellar paywall shows the payment receipt before loading the
+   * paid content. Defaults to 3000ms; `0` hands off immediately.
+   */
+  stellarReceiptDelayMs?: number;
 }
 
 export interface PaymentRequirements {


### PR DESCRIPTION
# feat(paywall): show a receipt for the settled payment before loading the content

**Branch:** `feat/paywall-receipt`
**Screenshot:** `harness/shots/after-receipt.png`

## The gap

On success the paywall calls `onSuccessfulResponse` immediately, and the default
implementation in `entry.tsx` does:

```ts
document.documentElement.innerHTML = await response.text();
```

The whole document is replaced. The payer never sees what they were charged,
which account was paid, or the hash it settled under — the one piece of evidence
that the payment was real and checkable on-ledger.

`examples/simple-paywall` works around this by injecting a `{{TX_LINK}}`
placeholder into its own paid page (`txHashInjector.ts`), but that only helps
hosts serving HTML they control. Anyone serving JSON, a file, or a page they do
not template gets nothing.

## The change

- `useStellarPayment` decodes the `PAYMENT-RESPONSE` header on the settled
  response and times the settlement, then reports both through a new optional
  `onReceipt`.
- `onReceipt` is **awaited**, so the caller can hold the hand-off. The paywall
  shows amount, recipient, transaction hash linked to Stellar Expert, and how
  long settlement took, then loads the content after `receiptDelayMs` (default
  3000) or as soon as Continue is pressed.
- Hosts control this through `stellarReceiptDelayMs` on `PaywallConfig`.
  Setting it to `0` skips the receipt and restores exactly the previous
  hand-off-immediately behaviour.

## Behaviour change

The 3000ms pause is the one behavioural change in this PR. I think a payer
should see proof of a payment they just authorised, but it is your call —
**happy to ship it as `0` by default so the receipt is opt-in.** Everything else
here is additive.

## Details worth flagging

- The explorer link falls back to the network named in the payment requirement
  when the facilitator reports one that is not CAIP-2, rather than dropping the
  link.
- A hand-off left pending at unmount is resolved in a cleanup effect, so the
  paid content can never be stranded behind an unresolved promise.
- Both success paths — first response and the 402-retry path — go through the
  same `completePayment`, each timed from its own submission.

## Tests

12 new cases covering the explorer URL builder (testnet, the `pubnet` → `public`
mapping, missing inputs, non-Stellar networks, and path-escaping a hostile
hash), hash truncation, and duration formatting.

---

Part of #74.
