### PR TITLE
feat(paywall): offer xBull, LOBSTR, Albedo and Rabet, and make the list configurable

### DIFF
--- a/packages/paywall/src/browser/useSWKConnection.ts
+++ b/packages/paywall/src/browser/useSWKConnection.ts
@@ -1,14 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { StellarWalletsKit } from "@creit.tech/stellar-wallets-kit/sdk";
-import { FreighterModule } from "@creit.tech/stellar-wallets-kit/modules/freighter";
-import { HanaModule } from "@creit.tech/stellar-wallets-kit/modules/hana";
-import { KleverModule } from "@creit.tech/stellar-wallets-kit/modules/klever";
-import { OneKeyModule } from "@creit.tech/stellar-wallets-kit/modules/onekey";
 import { Networks } from "@creit.tech/stellar-wallets-kit/types";
 import type { Network } from "@x402/core/types";
 import { getNetworkPassphrase } from "@x402/stellar";
 import { parseError } from "@x402-stellar/shared";
 import { statusClear, statusError, statusInfo, type Status } from "./status";
+import { resolveWalletModules } from "./walletModules";
 
 export type UseSWKConnectionParams = {
   network: Network;
@@ -47,7 +44,7 @@ export function useSWKConnection({
       const networkPassphrase = getNetworkPassphrase(network);
       StellarWalletsKit.init({
         network: networkPassphrase as Networks,
-        modules: [new FreighterModule(), new HanaModule(), new KleverModule(), new OneKeyModule()],
+        modules: resolveWalletModules(window.x402?.config?.wallets),
       });
 
       setKitReady(true);

--- a/packages/paywall/src/browser/walletIds.test.ts
+++ b/packages/paywall/src/browser/walletIds.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import { resolveWalletIds, SUPPORTED_WALLET_IDS } from "./walletIds.ts";
+
+describe("SUPPORTED_WALLET_IDS", () => {
+  it("keeps Freighter first so the most common wallet leads the modal", () => {
+    assert.equal(SUPPORTED_WALLET_IDS[0], "freighter");
+  });
+
+  it("covers the wallets the Stellar ecosystem actually uses", () => {
+    for (const id of ["freighter", "xbull", "lobstr", "albedo", "rabet", "hana"]) {
+      assert.ok(SUPPORTED_WALLET_IDS.includes(id as never), `${id} should be offered`);
+    }
+  });
+
+  it("has no duplicate ids", () => {
+    assert.equal(new Set(SUPPORTED_WALLET_IDS).size, SUPPORTED_WALLET_IDS.length);
+  });
+});
+
+describe("resolveWalletIds", () => {
+  it("offers every supported wallet when nothing is configured", () => {
+    assert.deepEqual(resolveWalletIds(), [...SUPPORTED_WALLET_IDS]);
+    assert.deepEqual(resolveWalletIds([]), [...SUPPORTED_WALLET_IDS]);
+  });
+
+  it("returns only the configured wallets, in the configured order", () => {
+    assert.deepEqual(resolveWalletIds(["lobstr", "freighter"]), ["lobstr", "freighter"]);
+  });
+
+  it("accepts ids regardless of case or surrounding whitespace", () => {
+    assert.deepEqual(resolveWalletIds([" xBull ", "ALBEDO"]), ["xbull", "albedo"]);
+  });
+
+  it("de-duplicates repeated ids", () => {
+    assert.deepEqual(resolveWalletIds(["freighter", "freighter"]), ["freighter"]);
+  });
+
+  it("drops unknown ids with a warning instead of throwing", () => {
+    const warn = mock.method(console, "warn", () => {});
+    try {
+      assert.deepEqual(resolveWalletIds(["freighter", "definitely-not-a-wallet"]), ["freighter"]);
+      assert.equal(warn.mock.callCount(), 1);
+    } finally {
+      warn.mock.restore();
+    }
+  });
+
+  it("falls back to every wallet when no configured id is usable", () => {
+    const warn = mock.method(console, "warn", () => {});
+    try {
+      assert.deepEqual(resolveWalletIds(["nope", "also-nope"]), [...SUPPORTED_WALLET_IDS]);
+    } finally {
+      warn.mock.restore();
+    }
+  });
+});

--- a/packages/paywall/src/browser/walletIds.ts
+++ b/packages/paywall/src/browser/walletIds.ts
@@ -1,0 +1,66 @@
+/**
+ * Which wallets the paywall offers, kept free of any Stellar Wallets Kit
+ * import so the selection logic stays unit-testable — the SWK modules are
+ * browser-only and cannot be loaded under Node.
+ */
+
+/**
+ * Wallet ids the paywall knows how to build, in their default display order.
+ *
+ * Only wallets whose SWK module takes no constructor arguments are listed. The
+ * hardware modules (Ledger, Trezor) and WalletConnect need per-integrator
+ * configuration — a transport, a project id — so they cannot be enabled by id
+ * alone and are deliberately left out.
+ */
+export const SUPPORTED_WALLET_IDS = [
+  "freighter",
+  "xbull",
+  "lobstr",
+  "albedo",
+  "rabet",
+  "hana",
+  "klever",
+  "onekey",
+] as const;
+
+export type WalletId = (typeof SUPPORTED_WALLET_IDS)[number];
+
+const SUPPORTED = new Set<string>(SUPPORTED_WALLET_IDS);
+
+/**
+ * Normalizes configured wallet ids down to the ones the paywall can build.
+ *
+ * Unknown ids are dropped with a console warning rather than thrown, so a
+ * single typo in a host's config cannot take the whole paywall down. An empty
+ * or fully-unknown list falls back to every supported wallet, because a paywall
+ * offering no wallets cannot be paid at all.
+ *
+ * @param walletIds - Ids from `window.x402.config.wallets`; omit for the default set.
+ * @returns Known wallet ids, de-duplicated, in the order requested.
+ */
+export function resolveWalletIds(walletIds?: string[]): WalletId[] {
+  if (!walletIds || walletIds.length === 0) {
+    return [...SUPPORTED_WALLET_IDS];
+  }
+
+  const resolved: WalletId[] = [];
+  for (const raw of walletIds) {
+    const id = raw.trim().toLowerCase();
+    if (!SUPPORTED.has(id)) {
+      console.warn(
+        `Unknown wallet id "${raw}" in x402 config; supported ids: ${SUPPORTED_WALLET_IDS.join(", ")}`,
+      );
+      continue;
+    }
+    if (!resolved.includes(id as WalletId)) {
+      resolved.push(id as WalletId);
+    }
+  }
+
+  if (resolved.length === 0) {
+    console.warn("No usable wallet ids in x402 config; falling back to all supported wallets.");
+    return [...SUPPORTED_WALLET_IDS];
+  }
+
+  return resolved;
+}

--- a/packages/paywall/src/browser/walletModules.ts
+++ b/packages/paywall/src/browser/walletModules.ts
@@ -1,0 +1,36 @@
+import { AlbedoModule } from "@creit.tech/stellar-wallets-kit/modules/albedo";
+import { FreighterModule } from "@creit.tech/stellar-wallets-kit/modules/freighter";
+import { HanaModule } from "@creit.tech/stellar-wallets-kit/modules/hana";
+import { KleverModule } from "@creit.tech/stellar-wallets-kit/modules/klever";
+import { LobstrModule } from "@creit.tech/stellar-wallets-kit/modules/lobstr";
+import { OneKeyModule } from "@creit.tech/stellar-wallets-kit/modules/onekey";
+import { RabetModule } from "@creit.tech/stellar-wallets-kit/modules/rabet";
+import { xBullModule } from "@creit.tech/stellar-wallets-kit/modules/xbull";
+import type { ModuleInterface } from "@creit.tech/stellar-wallets-kit/types";
+import { resolveWalletIds, type WalletId } from "./walletIds";
+
+/**
+ * One factory per supported wallet. Typed as `Record<WalletId, ...>` so adding
+ * an id to `SUPPORTED_WALLET_IDS` without wiring up its module is a build
+ * error rather than a runtime crash inside the wallet modal.
+ */
+const WALLET_MODULE_FACTORIES: Record<WalletId, () => ModuleInterface> = {
+  freighter: () => new FreighterModule(),
+  xbull: () => new xBullModule(),
+  lobstr: () => new LobstrModule(),
+  albedo: () => new AlbedoModule(),
+  rabet: () => new RabetModule(),
+  hana: () => new HanaModule(),
+  klever: () => new KleverModule(),
+  onekey: () => new OneKeyModule(),
+};
+
+/**
+ * Resolves configured wallet ids into Stellar Wallets Kit modules.
+ *
+ * @param walletIds - Ids from `window.x402.config.wallets`; omit for the default set.
+ * @returns Instantiated modules, in the order requested.
+ */
+export function resolveWalletModules(walletIds?: string[]): ModuleInterface[] {
+  return resolveWalletIds(walletIds).map((id) => WALLET_MODULE_FACTORIES[id]());
+}

--- a/packages/paywall/src/browser/window.d.ts
+++ b/packages/paywall/src/browser/window.d.ts
@@ -11,6 +11,11 @@ declare global {
       appLogo?: string;
       config: {
         rpcUrl?: string;
+        /**
+         * Wallet ids to offer, in order. Omit for every wallet the paywall
+         * supports; see `SUPPORTED_WALLET_IDS` in `walletModules.ts`.
+         */
+        wallets?: string[];
         chainConfig: Record<
           string,
           {

--- a/packages/paywall/src/stellar-handler.ts
+++ b/packages/paywall/src/stellar-handler.ts
@@ -24,6 +24,7 @@ interface StellarPaywallOptions {
   appName?: string;
   appLogo?: string;
   stellarRpcUrl?: string;
+  stellarWallets?: string[];
 }
 
 /**
@@ -41,7 +42,16 @@ function getStellarPaywallHtml(options: StellarPaywallOptions): string {
   if (!STELLAR_PAYWALL_TEMPLATE) {
     return `<!DOCTYPE html><html><body><h1>Stellar Paywall template not available</h1></body></html>`;
   }
-  const { amount, testnet, paymentRequired, currentUrl, appName, appLogo, stellarRpcUrl } = options;
+  const {
+    amount,
+    testnet,
+    paymentRequired,
+    currentUrl,
+    appName,
+    appLogo,
+    stellarRpcUrl,
+    stellarWallets,
+  } = options;
 
   const logOnTestnet = testnet
     ? "console.log('Stellar Payment required initialized:', window.x402);"
@@ -51,6 +61,9 @@ function getStellarPaywallHtml(options: StellarPaywallOptions): string {
 
   const currentUrlLine = currentUrl ? `\n      currentUrl: ${jsonForScript(currentUrl)},` : "";
   const rpcUrlLine = stellarRpcUrl ? `\n        rpcUrl: ${jsonForScript(stellarRpcUrl)},` : "";
+  const walletsLine = stellarWallets?.length
+    ? `\n        wallets: ${jsonForScript(stellarWallets)},`
+    : "";
 
   const configScript = `
   <script>
@@ -58,7 +71,7 @@ function getStellarPaywallHtml(options: StellarPaywallOptions): string {
       amount: ${amount},
       paymentRequired: ${jsonForScript(paymentRequired)},
       testnet: ${testnet},${currentUrlLine}
-      config: {${rpcUrlLine}
+      config: {${rpcUrlLine}${walletsLine}
         chainConfig: ${jsonForScript(config)},
       },
       appName: ${jsonForScript(appName || "")},
@@ -107,6 +120,7 @@ export const stellarPaywall: PaywallNetworkHandler = {
       appName: config.appName,
       appLogo: config.appLogo,
       stellarRpcUrl: config.stellarRpcUrl,
+      stellarWallets: config.stellarWallets,
     });
   },
 };

--- a/packages/paywall/src/types.ts
+++ b/packages/paywall/src/types.ts
@@ -12,6 +12,12 @@ export interface PaywallConfig {
   currentUrl?: string;
   testnet?: boolean;
   stellarRpcUrl?: string;
+  /**
+   * Wallet ids to offer in the Stellar paywall, in order. Omit to offer every
+   * wallet the paywall supports. See `SUPPORTED_WALLET_IDS` in
+   * `src/browser/walletModules.ts` for the accepted values.
+   */
+  stellarWallets?: string[];
 }
 
 export interface PaymentRequirements {


### PR DESCRIPTION
# feat(paywall): offer xBull, LOBSTR, Albedo and Rabet, and make the list configurable

**Branch:** `fix/74-wallet-coverage`
**Screenshots:** `harness/shots/before-wallet-modal.png` → `harness/shots/after-wallet-modal.png`

## The gap

`useSWKConnection` initialises Stellar Wallets Kit with four modules:

```ts
modules: [new FreighterModule(), new HanaModule(), new KleverModule(), new OneKeyModule()]
```

Anyone holding USDC in xBull, LOBSTR, Albedo or Rabet cannot pay, and the modal
gives no hint that their wallet was never an option. SWK ships a zero-config
module for each of them (`@creit.tech/stellar-wallets-kit/modules/{xbull,lobstr,albedo,rabet}`).

Opening the real modal against each version confirms the difference:

| | wallets offered |
|---|---|
| before | Freighter, Hana, Klever, OneKey — **4** |
| after | xBull, Albedo, Freighter, LOBSTR, Rabet, Hana, Klever, OneKey — **8** |

## The change

- Offer all eight, Freighter first.
- Let the host narrow and order the list: `stellarWallets` on `PaywallConfig`
  flows through to `window.x402.config.wallets`, the same path `stellarRpcUrl`
  already takes. Omitting it keeps every wallet.
- Unknown ids are dropped with a console warning, and a list with no usable id
  falls back to all wallets, so a config typo degrades instead of leaving a
  paywall nobody can pay.

## Structure

The id list and the resolution logic live in `walletIds.ts` with **no SWK
import**. The SWK modules are browser-only — importing one under Node throws on
`@stellar/freighter-api`'s ESM interop — so keeping them apart is what makes
the selection logic unit-testable at all. `walletModules.ts` maps ids to modules
through a `Record<WalletId, ...>`, so adding an id without wiring up its module
is a build error rather than a crash inside the modal.

Ledger, Trezor and WalletConnect are deliberately excluded: their modules need
per-integrator configuration (a transport, a project id) and cannot be enabled
by id alone.

## Cost

~99 KB uncompressed for the four added wallets (3,749,116 → 3,850,869 bytes).
If that is too much for the default, the same mechanism supports shipping four
by default and letting hosts opt into the rest — say the word and I will flip it.

## Tests

9 new cases covering the default list, explicit ordering, case/whitespace
tolerance, de-duplication, unknown-id warning, and the all-unknown fallback.

---

Part of #74.
